### PR TITLE
fix: update scalar import to improved cdn

### DIFF
--- a/crates/oapi/src/scalar/mod.rs
+++ b/crates/oapi/src/scalar/mod.rs
@@ -53,7 +53,7 @@ impl Scalar {
     /// ```
     pub fn new(spec_url: impl Into<String>) -> Self {
         Self {
-            lib_url: "https://www.unpkg.com/@scalar/api-reference".into(),
+            lib_url: "https://cdn.jsdelivr.net/npm/@scalar/api-reference".into(),
             spec_url: spec_url.into(),
         }
     }


### PR DESCRIPTION
jsdelivr is half the size of unpkg so it loads faster and provides a better user experience with the smaller bundle size. This is our default cdn now.